### PR TITLE
fix(env): corrige carregamento da variável ALPHA_VANTAGE_API_KEY

### DIFF
--- a/internal/handlers/financial_query_handler.go
+++ b/internal/handlers/financial_query_handler.go
@@ -6,9 +6,16 @@ import (
 	"io"
 	"net/http"
 	"os"
+
+	"github.com/joho/godotenv"
 )
 
-var alphaVantageAPIKey = os.Getenv("ALPHA_VANTAGE_API_KEY")
+var alphaVantageAPIKey string
+
+func init() {
+	godotenv.Load()
+	alphaVantageAPIKey = os.Getenv("ALPHA_VANTAGE_API_KEY")
+}
 
 func QueryStockPriceHandler(w http.ResponseWriter, r *http.Request) {
 	type Request struct {


### PR DESCRIPTION
### **Corrige carregamento de variável de ambiente `ALPHA_VANTAGE_API_KEY`**  

#### **Descrição do problema**  
A variável `alphaVantageAPIKey` estava sendo inicializada antes do carregamento das variáveis de ambiente, resultando em um valor vazio. Como `godotenv.Load()` é chamado no `main.go`, a inicialização global da variável ocorria **antes** de as variáveis de ambiente serem carregadas, causando um erro silencioso.  
Além disso, a inicialização da variável dentro do arquivo `financial_query_handler.go` também seguia essa mesma abordagem incorreta, causando um comportamento inconsistente.  

#### **Correção aplicada**  
- Move a inicialização da variável `alphaVantageAPIKey` para a função `init()`, garantindo que `os.Getenv()` tenha acesso às variáveis carregadas corretamente.  
- Remove a inicialização prematura da variável global no `financial_query_handler.go`.  
- Atualiza a estrutura do código para seguir boas práticas de carregamento de variáveis de ambiente.  

#### **Mudanças no código**  
Antes (código com erro no `financial_query_handler.go`):  
```go
var alphaVantageAPIKey = os.Getenv("ALPHA_VANTAGE_API_KEY")

func QueryStockPriceHandler(w http.ResponseWriter, r *http.Request) {
    log.Println("API Key:", alphaVantageAPIKey) // Variável pode estar vazia
}
```
Depois (código corrigido):  
```go
var alphaVantageAPIKey string

func init() {
    godotenv.Load()
    alphaVantageAPIKey = os.Getenv("ALPHA_VANTAGE_API_KEY") // Variável é carregada corretamente
}

func QueryStockPriceHandler(w http.ResponseWriter, r *http.Request) {
    log.Println("API Key:", alphaVantageAPIKey) // Agora a variável contém o valor esperado
}
```

#### **Testes realizados**  
- Testado localmente com diferentes cenários de `.env` para garantir que a variável seja carregada corretamente.
- Validado que `alphaVantageAPIKey` contém o valor correto após `godotenv.Load()`.
- Confirmado que `os.Getenv()` retorna o valor esperado quando a inicialização ocorre dentro de `init()`.
- Testado que a função `QueryStockPriceHandler` agora recebe o valor esperado da variável.

#### **Como reproduzir o bug**  
1. Definir `ALPHA_VANTAGE_API_KEY` no arquivo `.env`.  
2. Rodar o código sem a correção e verificar que `alphaVantageAPIKey` está vazia no `financial_query_handler.go`.  
3. Aplicar a correção e validar que a variável contém o valor esperado na função `QueryStockPriceHandler`.
